### PR TITLE
Load internal resources before records in tests

### DIFF
--- a/src/actions/actions.go
+++ b/src/actions/actions.go
@@ -35,6 +35,7 @@ type ActionType string
 // Action types
 const (
 	ActionActWindow   ActionType = "ir.actions.act_window"
+	ActionURL         ActionType = "ir.actions.act_url"
 	ActionServer      ActionType = "ir.actions.server"
 	ActionReport      ActionType = "ir.actions.report"
 	ActionClient      ActionType = "ir.actions.client"

--- a/src/tests/testing.go
+++ b/src/tests/testing.go
@@ -115,6 +115,7 @@ func InitializeTests(moduleName string) {
 	models.BootStrap()
 	resourceDir, _ := filepath.Abs(filepath.Join(".", "res"))
 	server.ResourceDir = resourceDir
+	server.LoadInternalResources(resourceDir)
 	if !dbExists || !keepDB {
 		fmt.Println("Upgrading schemas in database", dbName)
 		models.SyncDatabase()
@@ -122,7 +123,6 @@ func InitializeTests(moduleName string) {
 		server.LoadDataRecords(resourceDir)
 		server.LoadDemoRecords(resourceDir)
 	}
-	server.LoadInternalResources(resourceDir)
 	views.BootStrap()
 	templates.BootStrap()
 	actions.BootStrap()


### PR DESCRIPTION
Because records may depend on internal resources
such as actions.